### PR TITLE
Move Docker CMD to Entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN uv sync --frozen
 
 COPY . .
 
-CMD ["uv", "run", "main.py"]
+CMD ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+uv run main.py


### PR DESCRIPTION
I thought this was a bit too simple for an issue so I made it a PR directly from github.dev :D, need to test later that we don't need to chmod +x the file or sth.

This would allow better customizability for the Dockerfile in the future, it's guaranteed to the user that they can just run ./entrypoint.sh && my-custom-logic.sh and have the script execute first and can then do post-processing later (my use case here: write to FS .csv and then apply that against a (potentially) fleet of meilisearch servers.

What do you think @moll-re ?